### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,5 @@ Installation
 ------------
 
 1. Clone the repository (`git clone https://github.com/maurodec/konsole-monokai.git`) or download `Monokai.colorscheme` (`wget https://github.com/maurodec/konsole-monokai/blob/master/Monokai.colorscheme?raw=True`).
-2. Copy `Monokai.colorscheme` to Konsole's directory. You can find it under `~/.kde/share/apps/konsole`.
-3. Restart Konsole.
-4. Go to `Settings` > `Edit Current Profile` and select the `Appearance` tab. Find Monokai in the list, select it and click the `OK` button.
+2. Copy `Monokai.colorscheme` to Konsole's directory. You can find it under `~/.local/share/konsole/`.
+3. Go to `Settings` > `Edit Current Profile` and select the `Appearance` tab. Find Monokai in the list, select it and click the `OK` button.


### PR DESCRIPTION
- Konsole's directory is now located at `~/.local/share/konsole/`
- Konsole no longer needs to be restarted